### PR TITLE
fix: deploy only runs after release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Build and Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [ main ]
   repository_dispatch:
     types: [trigger-deploy]
   workflow_dispatch:
@@ -27,7 +25,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
+          cache: 'npm'
           
       - name: Install Dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ A central manifest file (`quiz_manifest.json`) maintains an index of all availab
    - Triggered by the release workflow
    - Zero-downtime deployment
 
+4. **Setup Instructions**
+   - Configure GitHub Pages:
+     1. Go to Repository Settings > Pages > Build and Deployment
+     2. Select "GitHub Actions" as the source
+   - Configure Release Token:
+     1. Go to Repository Settings > Actions secrets and variables > Repository secrets
+     2. Add a new secret named `RELEASE_PLEASE_TOKEN`
+     3. Set the value to a GitHub Personal Access Token with `repo` scope
+
 ## Performance Optimization
 
 ### Network Optimization


### PR DESCRIPTION
Ensure deploy workflow only runs after a successful release creation.