### PR TITLE
chore: update release workflow to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write  # Needed for label creation
 
 jobs:
   release-please:
@@ -19,7 +20,7 @@ jobs:
         with:
           release-type: node
           package-name: quiz-nghiep-vu
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           
       # Only run the following steps if a release was created
       - name: Checkout 🛎️
@@ -42,5 +43,5 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           event-type: trigger-deploy


### PR DESCRIPTION
## Changes
- Update release workflow to use GITHUB_TOKEN instead of RELEASE_PLEASE_TOKEN
- Add issues permission for label creation
- Maintain release-please configuration for node package

## Testing
- Workflow should trigger on direct pushes to main branch
- Release creation should work as expected with new token configuration