### PR TITLE
fix: package-name in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         id: release
         with:
           release-type: node
-          package-name: quiz-nghiep-vu
           token: ${{ secrets.GITHUB_TOKEN }}
           
       # Only run the following steps if a release was created


### PR DESCRIPTION
package-name is not a valid input parameter for the googleapis/release-please-action@v4.
Release Please typically determines the package(s) to release based on the release-type and potentially a path or configuration files, rather than a direct package-name input at the action level for standard types like node